### PR TITLE
Add basic entries app with Prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Akış Bilinci Uygulaması
 
-Next.js tabanlı temel başlangıç arayüzü.
+Bu proje Next.js 13 tabanlıdır ve `app` dizinini kullanır. Kullanıcılar kategori ve metin girerek içerik ekler. Veriler `/api/entries` API'si üzerinden SQLite veritabanına Prisma aracılığıyla kaydedilir. Kayıtlar ana sayfada listelenir.
+
+## Geliştirme
+
+1. `npm install` komutuyla bağımlılıkları kurun.
+2. `npx prisma migrate dev --name init` komutu ile SQLite veritabanını oluşturun.
+3. `npm run dev` ile uygulamayı başlatın.

--- a/app/api/entries/route.js
+++ b/app/api/entries/route.js
@@ -1,0 +1,12 @@
+import { prisma } from '../../../lib/prisma';
+
+export async function POST(req) {
+  const data = await req.json();
+  const entry = await prisma.entry.create({ data: { category: data.category, content: data.content } });
+  return new Response(JSON.stringify(entry), { status: 201, headers: { 'Content-Type': 'application/json' } });
+}
+
+export async function GET() {
+  const entries = await prisma.entry.findMany({ orderBy: { id: 'desc' } });
+  return new Response(JSON.stringify(entries), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,59 @@
+"use client";
+import { useState, useEffect } from 'react';
+
+export default function Page() {
+  const [category, setCategory] = useState("");
+  const [content, setContent] = useState("");
+  const [entries, setEntries] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/entries").then(res => res.json()).then(setEntries);
+  }, []);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    await fetch("/api/entries", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ category, content })
+    });
+    setCategory("");
+    setContent("");
+    const newEntries = await fetch("/api/entries").then(res => res.json());
+    setEntries(newEntries);
+  }
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Ak\u0131\u015f Bilinci Uygulamas\u0131</h1>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '2rem' }}>
+        <div>
+          <label>
+            Kategori:
+            <select value={category} onChange={e => setCategory(e.target.value)} required>
+              <option value="">Se\u00e7iniz</option>
+              <option value="g\u00fcnl\u00fck">G\u00fcnl\u00fck</option>
+              <option value="not">Not</option>
+              <option value="di\u011fer">Di\u011fer</option>
+            </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Metin:
+            <textarea value={content} onChange={e => setContent(e.target.value)} required />
+          </label>
+        </div>
+        <button type="submit">Kaydet</button>
+      </form>
+
+      <ul>
+        {entries.map(entry => (
+          <li key={entry.id}>
+            <strong>{entry.category}</strong>: {entry.content}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis;
+
+export const prisma = globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/next.config.js
+++ b/next.config.js
@@ -1,1 +1,7 @@
-module.exports = { reactStrictMode: true };
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: { appDir: true }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "next": "13.5.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "@prisma/client": "5.7.1",
+    "prisma": "5.7.1"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,15 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Entry {
+  id        Int      @id @default(autoincrement())
+  category  String
+  content   String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- switch to `app` directory and enable experimental appDir
- implement `/api/entries` endpoint using Prisma SQLite
- add client form in `app/page.js` to post and list entries
- define Prisma schema and client helper
- document setup steps in README
- add Prisma packages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839f55507c832998c217c4f3e3c3d7